### PR TITLE
Switch layer instead of style

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   {
     title: 'Klassisk', // The title displayed in the styling selector
     img: 'img/klassisk.png', // File location of the image to be diplayed in the styling selector
-    style: 'styles/klassisk.json' // File location of the style file
+    style: 'styles/klassisk.json', // File location of the style file
+    id: 'b515c702380a' // A unique ID. Can be basically any truthy string. This one was generated using Math.random().toString(16).slice(2)
   }
 ```

--- a/src/components/layerSelector.js
+++ b/src/components/layerSelector.js
@@ -138,6 +138,7 @@ export class MapLayerSelector extends HTMLElement {
         const jsonFile = JSON.parse(e.target.result)
         // Add new style element to the list
         const styleElement = this.createStyleElement({
+          id: Math.random().toString(16).slice(2),
           title: (fileName.length > maxTitleLength) ? fileName.slice(0, maxTitleLength-1) + '&hellip;' : str,
           style: jsonFile
         }, '', stylesElement)
@@ -172,13 +173,11 @@ export class MapLayerSelector extends HTMLElement {
         stylesElement.children[i].classList.remove(selectedClass)
       }
       wrapperElement.classList.add(selectedClass)
-      // Use timeout hack to allow highlight of selection to update before updating the map.
-      // Otherwise it does not update until the new style has also rendered.
-      setTimeout(() => {
-        this.dispatchEvent(new CustomEvent('vt:change-style', { 
-          detail: style, bubbles: true, composed: true 
-        }))
-      }, 1)
+      this.dispatchEvent(new CustomEvent('vt:change-style', { 
+        detail: style,
+        bubbles: true,
+        composed: true
+      }))
     })
     return wrapperElement
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,21 +2,25 @@ export const STYLE_FILES = [
   {
     title: 'Klassisk', // The title displayed in the styling selector
     img: 'img/klassisk.png', // File location of the image to be diplayed in the styling selector
-    style: 'styles/klassisk.json' // File location of the style file
+    style: 'styles/klassisk.json', // File location of the style file,
+    id: 'b515c702380a' // A unique ID. Can be basically any truthy string. This one was generated using Math.random().toString(16).slice(2)
   },
   {
     title: 'Dæmpet',
     img: 'img/daempet.png',
-    style: 'styles/daempet.json'
+    style: 'styles/daempet.json',
+    id: 'ef4a2e8e7e17c'
   },
   {
     title: 'Grå',
     img: 'img/graa.png',
-    style: 'styles/graa.json'
+    style: 'styles/graa.json',
+    id: '817329b659da5'
   },
   {
     title: 'Mørkt',
     img: 'img/moerkt.png',
-    style: 'styles/moerkt.json'
+    style: 'styles/moerkt.json',
+    id: '0f01f2c271858'
   }
 ]


### PR DESCRIPTION
Allows for faster switching, but names are missing from layers other than the first until a new layer is added.
[stylefile_mikar.json](https://github.com/user-attachments/files/15613680/stylefile_mikar.json)
